### PR TITLE
fix: Add docker group to container on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14
+      options: --group-add 121
   release_github:
     name: Publish to GitHub Releases
     needs: release

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -62,4 +62,10 @@ const buildWorkflow = project.tryFindObjectFile('.github/workflows/build.yml');
 buildWorkflow.patch(
   JsonPatch.add('/jobs/build/container/options', '--group-add 121')
 );
+const releaseWorkflow = project.tryFindObjectFile(
+  '.github/workflows/release.yml'
+);
+releaseWorkflow.patch(
+  JsonPatch.add('/jobs/release/container/options', '--group-add 121')
+);
 project.synth();


### PR DESCRIPTION
Fixes #36 

Adds docker permission on release container which runs tests prior to release