### PR TITLE
fix: account for spaces in a role/policy/instanceprofile name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,10 @@ jobs:
         id: self_mutation
         run: |-
           git add .
-          git diff --staged --patch --exit-code > .repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
+          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=self_mutation_happened::true"
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: .repo.patch
           path: .repo.patch
@@ -44,7 +44,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2.1.1
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,14 @@ jobs:
         run: npx projen release
       - name: Check for new commits
         id: git_remote
-        run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+        run: echo ::set-output name=latest_commit::"$(git ls-remote origin -h ${{ github.ref }} | cut -f1)"
       - name: Backup artifact permissions
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2.1.1
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -26,10 +26,10 @@ jobs:
         id: create_patch
         run: |-
           git add .
-          git diff --staged --patch --exit-code > .repo.patch || echo "patch_created=true" >> $GITHUB_OUTPUT
+          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=patch_created::true"
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: .repo.patch
           path: .repo.patch

--- a/src/patches/addPermissionsBoundary.ts
+++ b/src/patches/addPermissionsBoundary.ts
@@ -66,11 +66,11 @@ export class AddPermissionBoundary implements IAspect {
   ): void {
     if (!cdkProp?.startsWith(prefix)) {
       const policySuffix = !Token.isUnresolved(cdkProp)
-        ? cdkProp
+        ? (cdkProp as string)
         : getResourceId(node.node.path);
       node.addPropertyOverride(
         cfnProp,
-        `${prefix}${policySuffix}`.substring(0, length - 1)
+        `${prefix}${policySuffix.replace(/\s/g, '')}`.substring(0, length - 1)
       );
     }
   }

--- a/test/patches/addPermissionsBoundary.test.ts
+++ b/test/patches/addPermissionsBoundary.test.ts
@@ -104,6 +104,22 @@ describe('Permissions Boundary patch', () => {
         },
       });
     });
+    test('Roles with spaces in id are supported', () => {
+      const idWithSpaces: string = 'A Role With Spaces In name';
+      new Role(stack, idWithSpaces, {
+        assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
+      });
+      Aspects.of(stack).add(
+        new AddPermissionBoundary({
+          permissionsBoundaryPolicyName: pbName,
+          rolePrefix: 'Bananas_',
+        })
+      );
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::IAM::Role', {
+        RoleName: `Bananas_Default-${idWithSpaces.replace(/\s/g, '')}-Resource`,
+      });
+    });
   });
   describe('Policies', () => {
     const policyPrefix = 'POLICY_PREFIX_';


### PR DESCRIPTION
Fixes #69 

Ensuring no spaces can end up in:

- `RoleName`
- `PolicyName`
- `ManagedPolicyName`
- `InstanceProfileName`