### PR TITLE
fix: Allow resource extractor to reference multiple values

### DIFF
--- a/src/patches/resource-extractor/resourceExtractor.ts
+++ b/src/patches/resource-extractor/resourceExtractor.ts
@@ -452,7 +452,7 @@ export class ResourceExtractor implements IAspect {
     }
 
     if (this.valueShareMethod == ResourceExtractorShareMethod.SSM_PARAMETER) {
-      shareName = shareName.replace(':', '/').replace(':', '/');
+      shareName = shareName.replace(/:/g, '/');
       const paramName = `/${shareName}`;
       const paramLogicalId = `p${shareName}`;
 


### PR DESCRIPTION
Fixes #132 

This PR appends the attribute that is being looked up if the intrinsic function type is Fn::GetAtt. This will allow the resource extractor to create multiple exports if a user is attempting to reference multiple values in an object. For example, a `kmsId` and a `kmsArn`.

This is a breaking change, since it modifies the way the resources are exported. If a user is currently using the resource extractor and updates to a version with this fix, they may get unexpected results.