### PR TITLE
fix: Update AddPermissionBoundary to handle compliant roleName properties

### DIFF
--- a/src/patches/addPermissionsBoundary.ts
+++ b/src/patches/addPermissionsBoundary.ts
@@ -7,7 +7,6 @@ import {
   CfnInstanceProfile,
   CfnManagedPolicy,
   CfnPolicy,
-  CfnRole,
 } from 'aws-cdk-lib/aws-iam';
 import { IConstruct } from 'constructs';
 import { getResourceId } from '../utils/utils';
@@ -97,34 +96,14 @@ export class AddPermissionBoundary implements IAspect {
           'PermissionsBoundary',
           permissionsBoundaryPolicyArn
         );
-        this.checkAndOverride(
-          node,
-          this._rolePrefix,
-          64,
-          'RoleName',
-          cfnResourceNode.logicalId
-        );
+        const roleName =
+          // eslint-disable-next-line dot-notation
+          cfnResourceNode['cfnProperties'].roleName ||
+          cfnResourceNode.logicalId;
+        this.checkAndOverride(node, this._rolePrefix, 64, 'RoleName', roleName);
       }
     }
-    if (node instanceof CfnRole) {
-      const permissionsBoundaryPolicyArn = Stack.of(node).formatArn({
-        service: 'iam',
-        resource: 'policy',
-        region: '',
-        resourceName: this._permissionsBoundaryPolicyName,
-      });
-      node.addPropertyOverride(
-        'PermissionsBoundary',
-        permissionsBoundaryPolicyArn
-      );
-      this.checkAndOverride(
-        node,
-        this._rolePrefix,
-        64,
-        'RoleName',
-        node.roleName
-      );
-    } else if (node instanceof CfnPolicy) {
+    if (node instanceof CfnPolicy) {
       this.checkAndOverride(
         node,
         this._policyPrefix,

--- a/test/patches/addPermissionsBoundary.test.ts
+++ b/test/patches/addPermissionsBoundary.test.ts
@@ -120,6 +120,25 @@ describe('Permissions Boundary patch', () => {
         RoleName: `Bananas_Default-${idWithSpaces.replace(/\s/g, '')}-Resource`,
       });
     });
+    test('Role name is not altered if it already complies with naming convention', () => {
+      const rolePrefix = 'Cust_';
+      const roleName = `${rolePrefix}MyRole`;
+      new Role(stack, 'Role', {
+        roleName,
+        assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
+      });
+
+      Aspects.of(stack).add(
+        new AddPermissionBoundary({
+          permissionsBoundaryPolicyName: pbName,
+          rolePrefix,
+        })
+      );
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::IAM::Role', {
+        RoleName: roleName,
+      });
+    });
   });
   describe('Policies', () => {
     const policyPrefix = 'POLICY_PREFIX_';


### PR DESCRIPTION
Fixes #602

This PR updates the logic for handling IAM Roles in the AddPermissionBoundary aspect. It makes the following high-level changes:

1. It removes the separate logic between using `CfnResource` and `CfnRole`. The `CfnRole` appears to be compliant with the `CfnResource`, and the same logic can be used for both. No reason to separate them out. In the previous setup, it actually would execute both checks and updates, which was counter intuitive.
2. It checks for the existence of a `roleName` property on the CfnResource. If found, it uses that instead. Otherwise, it falls back to the logical Id
3. Added a test to verify that the expected behavior works for Roles. 