### PR TITLE
fix: Fix parent of new ManagedPolicy created by ConvertInlinePoliciesToManaged

### DIFF
--- a/test/patches/convertInlinePoliciesToManaged.test.ts
+++ b/test/patches/convertInlinePoliciesToManaged.test.ts
@@ -94,11 +94,6 @@ describe('Updating Resource Types', () => {
     Aspects.of(app).add(new ConvertInlinePoliciesToManaged());
     app.synth();
     const template = Template.fromStack(stack);
-    console.log((template as any).template.Resources);
-    console.log(
-      (template as any).template.Resources
-        .TestLambdaServiceRoleDefaultPolicy0F2D5E78
-    );
     let functions = template.findResources('AWS::Lambda::Function');
     let i = 0;
     for (const name of Object.keys(functions)) {


### PR DESCRIPTION
This PR updates the scope of the newly-created ManagedPolicy resource to keep the same parent as the deleted resource. A unit test is added to verify that the dependencies aren't lost (previously, the dependencies would only include the Role, not the associated policy)

Fixes #733 