### PR TITLE
fix: preserve cfn metadata

### DIFF
--- a/src/patches/convertInlinePoliciesToManaged.ts
+++ b/src/patches/convertInlinePoliciesToManaged.ts
@@ -36,6 +36,12 @@ export class ConvertInlinePoliciesToManaged implements IAspect {
       });
       resource.overrideLogicalId(logicalId);
 
+      // Preserve CloudFormation metadata from the original policy
+      const originalMetadata = policy.cfnOptions.metadata;
+      if (originalMetadata) {
+        resource.cfnOptions.metadata = originalMetadata;
+      }
+
       const overrides = (node as any).rawOverrides;
       if (overrides?.Properties?.PolicyName) {
         resource.addPropertyOverride(

--- a/test/patches/convertInlinePoliciesToManaged.test.ts
+++ b/test/patches/convertInlinePoliciesToManaged.test.ts
@@ -141,4 +141,36 @@ describe('Updating Resource Types', () => {
     appTemplate.resourceCountIs('AWS::S3::Bucket', 1);
     appTemplate.resourceCountIs('AWS::Lambda::Function', 1);
   });
+
+  test('Preserves CloudFormation metadata on converted policy', () => {
+    const role = new iam.Role(stack, 'TestRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+    const policy = new iam.Policy(stack, 'MyPolicy', {
+      roles: [role],
+    });
+    policy.addStatements(
+      new iam.PolicyStatement({
+        actions: ['s3:GetObject'],
+        resources: ['*'],
+      })
+    );
+    const cfnPolicy = policy.node.defaultChild as iam.CfnPolicy;
+    cfnPolicy.cfnOptions.metadata = {
+      'aws:cdk:path': 'some/path',
+      CustomKey: 'CustomValue',
+    };
+
+    Aspects.of(app).add(new ConvertInlinePoliciesToManaged());
+    app.synth();
+
+    const template = Template.fromStack(stack);
+    const managedPolicies = template.findResources('AWS::IAM::ManagedPolicy');
+    const policyKeys = Object.keys(managedPolicies);
+    expect(policyKeys.length).toBe(1);
+    const metadata = managedPolicies[policyKeys[0]].Metadata;
+    expect(metadata).toBeDefined();
+    expect(metadata.CustomKey).toBe('CustomValue');
+  });
 });
+

--- a/test/patches/convertInlinePoliciesToManaged.test.ts
+++ b/test/patches/convertInlinePoliciesToManaged.test.ts
@@ -173,4 +173,3 @@ describe('Updating Resource Types', () => {
     expect(metadata.CustomKey).toBe('CustomValue');
   });
 });
-


### PR DESCRIPTION
## fix(convertInlinePoliciesToManaged): preserve CloudFormation metadata when converting inline policies to managed

### Description

When the `ConvertInlinePoliciesToManaged` aspect converts `AWS::IAM::Policy` resources to `AWS::IAM::ManagedPolicy`, any CloudFormation metadata attached to the original `CfnPolicy` node (via `cfnOptions.metadata`) was silently dropped. This is because the aspect removes the original node and creates a new `CfnManagedPolicy` without copying the metadata over.

This fix copies `cfnOptions.metadata` from the original `CfnPolicy` to the replacement `CfnManagedPolicy`.

### Pull Request Checklist

- [x] Testing
  - Unit test added: `Preserves CloudFormation metadata on converted policy`
- [x] Docs
  - README update not necessary (no API change)
- [x] Title and Description
  - Change type: `fix`
  - Title: lower-case, no trailing period
  - Breaking: No
